### PR TITLE
Manually correct OSV-2020-902

### DIFF
--- a/vulns/qt/OSV-2020-902.yaml
+++ b/vulns/qt/OSV-2020-902.yaml
@@ -17,6 +17,7 @@ affects:
   - type: GIT
     repo: git://code.qt.io/qt/qt5.git
     introduced: 8a5938bd2288c13dfe41c289c8ed0647cfa412e9:176d9ce09c8abcc232a4bd5ebc2ac6d6413113af
+    fixed: 6cafc374865cf051cdda62b21323cd1e375f64ef:61d6a120dccb48e6bff78c4b5bf8913916416689
   versions:
   - v5.15.0
   - v5.15.0-beta4

--- a/vulns/qt/OSV-2020-902.yaml
+++ b/vulns/qt/OSV-2020-902.yaml
@@ -24,21 +24,7 @@ affects:
   - v5.15.0-rc2
   - v5.15.1
   - v5.15.2
-  - v6.0.0
-  - v6.0.0-alpha1
-  - v6.0.0-beta1
-  - v6.0.0-beta2
-  - v6.0.0-beta3
-  - v6.0.0-beta4
-  - v6.0.0-beta5
-  - v6.0.0-rc1
-  - v6.0.0-rc2
-  - v6.0.1
-  - v6.0.2
-  - v6.1.0-alpha1
-  - v6.1.0-beta1
-  - v6.1.0-beta2
 references:
 - https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24266
-modified: '2021-03-09T05:46:51.855826Z'
+modified: '2021-04-08T08:19:25.000000Z'
 created: '2020-07-21T00:00:16.344765Z'


### PR DESCRIPTION
See https://github.com/google/osv/issues/88 for reference.

The "Fixed in" range is not in the file. Is there a way to correct this, too?