### PR TITLE
[matio] Fix 2021-440

### DIFF
--- a/vulns/matio/OSV-2021-440.yaml
+++ b/vulns/matio/OSV-2021-440.yaml
@@ -22,6 +22,7 @@ affected:
     repo: git://git.code.sf.net/p/matio/matio
     events:
     - introduced: 1ce8f2d1845ecdde19a35605cabdbb884776d52d
+    - fixed: cddcdad17864c4b95ead23581047b41636f180a3
   versions:
   - v1.5.20
   - v1.5.21


### PR DESCRIPTION
CVE-2021-36977 was fixed en-passant when the libhdf5 dependency was updated from v1.12.0 to v.12.1 by https://github.com/google/oss-fuzz/commit/19ea576614a569893a1d8ed30d313d1cc25ac2cb. See also https://github.com/google/oss-fuzz/issues/4999 and https://github.com/HDFGroup/hdf5/issues/272.

FYI @inferno-chromium