### PR TITLE
[matio] Fix 2020-799

### DIFF
--- a/vulns/matio/OSV-2020-799.yaml
+++ b/vulns/matio/OSV-2020-799.yaml
@@ -22,6 +22,7 @@ affected:
     repo: git://git.code.sf.net/p/matio/matio
     events:
     - introduced: 651a8e28099edb5fbb9e4e1d4d3238848f446c9a
+    - fixed: cddcdad17864c4b95ead23581047b41636f180a3
   versions:
   - v1.5.18
   - v1.5.19


### PR DESCRIPTION
CVE-2020-36428 = OSV-2020-799 = https://oss-fuzz.com/testcase-detail/5668218489536512 is considered invalid as it no longer can be reproduced in a non-i386 config.