### PR TITLE
OSV-2022-715 vulnerability resolved in Pillow 9.3.0

### DIFF
--- a/vulns/pillow/OSV-2022-715.yaml
+++ b/vulns/pillow/OSV-2022-715.yaml
@@ -26,6 +26,7 @@ affected:
     repo: https://github.com/python-pillow/Pillow
     events:
     - introduced: c58d2817bc891c26e6b8098b8909c0eb2e7ce61b
+    - fixed: 9887544fafcd13cc8afcfa0c6d0f2e6facc1a8b8
   versions:
   - 9.1.0
   - 9.1.1

--- a/vulns/pillow/OSV-2022-715.yaml
+++ b/vulns/pillow/OSV-2022-715.yaml
@@ -2,6 +2,7 @@ id: OSV-2022-715
 summary: Segv on unknown address in jpeg_read_scanlines
 details: |
   OSS-Fuzz report: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50217
+  https://pillow.readthedocs.io/en/stable/releasenotes/9.3.0.html#decode-jpeg-compressed-blp1-data-in-original-mode
 
   ```
   Crash type: Segv on unknown address
@@ -10,7 +11,7 @@ details: |
   ImagingJpegDecode
   _decode
   ```
-modified: '2022-10-30T00:19:42.793664Z'
+modified: '2022-10-30T22:16:00.000000Z'
 published: '2022-08-15T00:00:50.156496Z'
 references:
 - type: REPORT
@@ -29,7 +30,6 @@ affected:
   - 9.1.0
   - 9.1.1
   - 9.2.0
-  - 9.3.0
   ecosystem_specific:
     severity: null
 schema_version: 1.3.0


### PR DESCRIPTION
Hi. I'm one of the core contributors to Pillow.

Regarding OSV-2022-715, the [OSS fuzz issue](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50217) thinks it was fixed in https://github.com/python-pillow/Pillow/compare/340f247672ce4b44cae43b3e566ed3236dd1a506...343f10aaf375b35395d072a023c30de936c04a01.
This is actually incorrect, and I've filed https://github.com/google/oss-fuzz/issues/8892 - the problem was really fixed in Pillow 9.3.0 by https://github.com/python-pillow/Pillow/pull/6678.
Either way though, the issue was fixed before Pillow 9.3.0, so this PR is trying to revert https://github.com/google/oss-fuzz-vulns/commit/f9c98bbd59c4f4cc0b49d2c43654d697fb1dc6d2

The release notes provide more details - https://pillow.readthedocs.io/en/stable/releasenotes/9.3.0.html#decode-jpeg-compressed-blp1-data-in-original-mode, so I've also added that link in this PR.