### PR TITLE
Update affected versions of OSV-2022-1074

### DIFF
--- a/vulns/pillow/OSV-2022-1074.yaml
+++ b/vulns/pillow/OSV-2022-1074.yaml
@@ -28,5 +28,8 @@ affected:
     - fixed: f7363c1091c70356d92e56abfca6b65bef9e7b26
   ecosystem_specific:
     severity: null
-  versions: []
+  versions:
+  - 9.1.0
+  - 9.1.1
+  - 9.2.0
 schema_version: 1.3.0

--- a/vulns/pillow/OSV-2022-1074.yaml
+++ b/vulns/pillow/OSV-2022-1074.yaml
@@ -10,7 +10,7 @@ details: |
   _Py_DECREF
   frame_dealloc
   ```
-modified: '2022-10-22T00:00:27.669183Z'
+modified: '2022-11-09T00:00:27.669183Z'
 published: '2022-10-22T00:00:27.668938Z'
 references:
 - type: REPORT


### PR DESCRIPTION
Hi. I'm one of the core contributors to Pillow.

Given that OSV-2022-1074 was fixed in [f7363c1091c70356d92e56abfca6b65bef9e7b26](https://github.com/python-pillow/Pillow/commit/f7363c1091c70356d92e56abfca6b65bef9e7b26) that means that it does not occur in Pillow >= 9.3.0.

The [release notes for that fix](https://pillow.readthedocs.io/en/latest/releasenotes/9.3.0.html#decode-jpeg-compressed-blp1-data-in-original-mode) state that the issue was introduced in Pillow 9.1.0.

So I've updated the affected [versions](https://github.com/python-pillow/Pillow/tags) accordingly.