### PR TITLE
Fix incorrectly-imported OSS-Fuzz issues

### DIFF
--- a/vulns/boringssl/OSV-2018-13.yaml
+++ b/vulns/boringssl/OSV-2018-13.yaml
@@ -10,8 +10,9 @@ details: |
   bn_reduce_once
   bn_from_montgomery_in_place
   ```
-modified: '2022-04-13T03:04:32.595447Z'
+modified: '2024-05-08T03:26:30.000000Z'
 published: '2021-01-13T00:00:05.629092Z'
+withdrawn: '2024-05-08T03:26:30.000000Z'
 references:
 - type: REPORT
   url: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=8654

--- a/vulns/boringssl/OSV-2018-206.yaml
+++ b/vulns/boringssl/OSV-2018-206.yaml
@@ -10,8 +10,9 @@ details: |
   SSL_CTX_set1_sigalgs_list
   std::__1::function<void
   ```
-modified: '2022-04-13T03:04:32.601109Z'
+modified: '2024-05-08T03:26:30.000000Z'
 published: '2021-01-13T00:01:24.412685Z'
+withdrawn: '2024-05-08T03:26:30.000000Z'
 references:
 - type: REPORT
   url: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=9808

--- a/vulns/boringssl/OSV-2023-41.yaml
+++ b/vulns/boringssl/OSV-2023-41.yaml
@@ -10,7 +10,7 @@ details: |
   ASN1_template_free
   asn1_item_combine_free
   ```
-modified: '2023-02-02T13:00:19.898346Z'
+modified: '2024-05-08T03:26:30.000000Z'
 published: '2023-02-02T13:00:19.898084Z'
 references:
 - type: REPORT
@@ -27,6 +27,6 @@ affected:
     - introduced: 33b569282ca124c81d9ba74df696a013cb9a80ae
     - fixed: 507ac830036d7531489490831814cf03e0d7c4d6
   ecosystem_specific:
-    severity: HIGH
+    severity: LOW
   versions: []
 schema_version: 1.3.0

--- a/vulns/boringssl/OSV-2024-417.yaml
+++ b/vulns/boringssl/OSV-2024-417.yaml
@@ -10,8 +10,9 @@ details: |
   bssl::ssl_create_cipher_list
   SSL_CTX_set_cipher_list
   ```
-modified: '2024-05-05T00:05:37.413546Z'
+modified: '2024-05-08T03:26:30.000000Z'
 published: '2024-05-05T00:05:37.413119Z'
+withdrawn: '2024-05-08T03:26:30.000000Z'
 references:
 - type: REPORT
   url: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68441

--- a/vulns/boringssl/OSV-2024-430.yaml
+++ b/vulns/boringssl/OSV-2024-430.yaml
@@ -10,8 +10,9 @@ details: |
   SSL_CTX_set1_groups_list
   std::__1::__function::__func<LLVMFuzzerTestOneInput::$_34, std::__1::allocator<L
   ```
-modified: '2024-05-05T00:14:35.047435Z'
+modified: '2024-05-08T03:26:30.000000Z'
 published: '2024-05-05T00:14:35.047133Z'
+withdrawn: '2024-05-08T03:26:30.000000Z'
 references:
 - type: REPORT
   url: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68473

--- a/vulns/boringssl/OSV-2024-432.yaml
+++ b/vulns/boringssl/OSV-2024-432.yaml
@@ -10,8 +10,9 @@ details: |
   std::__1::__function::__func<LLVMFuzzerTestOneInput::$_39, std::__1::allocator<L
   function.h
   ```
-modified: '2024-05-05T00:15:04.590235Z'
+modified: '2024-05-08T03:26:30.000000Z'
 published: '2024-05-05T00:15:04.589857Z'
+withdrawn: '2024-05-08T03:26:30.000000Z'
 references:
 - type: REPORT
   url: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68524


### PR DESCRIPTION
OSV-2018-13, OSV-2024-417, OSV-2024-430, and OSV-2024-432 were all OSS-Fuzz infrastructure regressions. When OSS-Fuzz breaks MSan, which is unfortunately quite often, the result is false positive reports. OSV seems to incorrectly classify these.

OSV-2018-206 was a bug in the fuzzer, not a bug in the library.

OSV-2023-41 was a bug in the library, but one we do not consider to be a security bug as this code is not safe for use with untrusted inputs, as documented in
https://commondatastorage.googleapis.com/chromium-boringssl-docs/x509.h.html#Deprecated-config-based-extension-creation

(The regression range is also wrong because it's flagging when the fuzzer was added, but I've left that alone.)