### PR TITLE
withdraw OSV-2021-823.yaml

### DIFF
--- a/vulns/bitcoin-core/OSV-2021-823.yaml
+++ b/vulns/bitcoin-core/OSV-2021-823.yaml
@@ -12,6 +12,7 @@ details: |
   ```
 modified: '2023-02-24T02:08:50.638741Z'
 published: '2021-06-03T00:01:12.500483Z'
+withdrawn: '2025-03-27T07:50:00Z'
 references:
 - type: REPORT
   url: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34845


### PR DESCRIPTION
As mentioned on the linked issue several times, the bug still reproduces (https://issues.oss-fuzz.com/issues/42497587#comment8), so the "fixed" range is wrong.

Also, the bug doesn't affect bitcoin-core (at most it affects only the fuzz target itself), but rather it seems to be a glibc issue on 32-bit , as mentioned in https://issues.oss-fuzz.com/issues/42530174#comment4.

The glibc bug would be fixed by https://github.com/google/oss-fuzz/pull/13018 in oss-fuzz, but this seems to be on hold.

Unrelatedly, oss-fuzz doesn't do any 32-bit fuzzing anymore right now, so any regression ranges or fixed ranges are stale anyway, see https://github.com/google/oss-fuzz/issues/13152.