### PR TITLE
fix: exit import script when issue id is missing

### DIFF
--- a/scripts/import.py
+++ b/scripts/import.py
@@ -28,9 +28,10 @@ _YamlDumper.add_representer(str, _yaml_str_representer)
 
 def main():
   if len(sys.argv) < 2:
-    print(f'Usage: {sys.argv[0]} <oss-fuzz issue_id>')
+    print(f'Usage: {sys.argv[0]} <oss-fuzz issue_id>', file=sys.stderr)
+    sys.exit(1)
 
-  issue_id = sys.argv[1]
+  issue_id = sys.argv[1]  
   try:
     data = urllib.request.urlopen(f'{_VULN_URL}/{issue_id}.json').read()
   except urllib.error.HTTPError:


### PR DESCRIPTION
## Summary

`scripts/import.py` currently prints a usage message when no OSS-Fuzz issue ID is provided, but then continues execution and accesses `sys.argv[1]`, which raises an unhandled `IndexError`.

## Fix

Exit with status code `1` after printing the usage message, and print the usage message to `stderr`.

## Reproduction

Before this change:

```bash
$ python scripts/import.py
Usage: scripts/import.py <oss-fuzz issue_id>
Traceback (most recent call last):
  File "scripts/import.py", line 54, in <module>
    main()
  File "scripts/import.py", line 33, in main
    issue_id = sys.argv[1]
IndexError: list index out of range
```

After this change:

```bash
$ python scripts/import.py
Usage: scripts/import.py <oss-fuzz issue_id>
$ echo $?
1
```

## Changes

- Print missing-argument usage to `stderr`
- Exit before accessing `sys.argv[1]` when no issue ID is provided