### PR TITLE
fix(jq): add fixed commit for OSV-2024-396 and OSV-2024-440

### DIFF
--- a/vulns/jq/OSV-2024-396.yaml
+++ b/vulns/jq/OSV-2024-396.yaml
@@ -8,6 +8,7 @@ affected:
   ranges:
   - events:
     - introduced: 5029328d35f3e60037970d27f350a742af41aa02
+    - fixed: 34f7186b86743a083a589741b6cea95293524108
     repo: https://github.com/jqlang/jq
     type: GIT
   versions:
@@ -16,7 +17,6 @@ affected:
   - jq-1.8.1
   - jq-1.8.2rc1
   - jq-1.8.2rc2
-  - jq-1.8.2
 details: |
   OSS-Fuzz report: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65942
 

--- a/vulns/jq/OSV-2024-440.yaml
+++ b/vulns/jq/OSV-2024-440.yaml
@@ -8,6 +8,7 @@ affected:
   ranges:
   - events:
     - introduced: 5029328d35f3e60037970d27f350a742af41aa02
+    - fixed: 34f7186b86743a083a589741b6cea95293524108
     repo: https://github.com/jqlang/jq
     type: GIT
   versions:
@@ -16,7 +17,6 @@ affected:
   - jq-1.8.1
   - jq-1.8.2rc1
   - jq-1.8.2rc2
-  - jq-1.8.2
 details: |
   OSS-Fuzz report: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=66323
 


### PR DESCRIPTION
## Summary

Adds `fixed` event to both jq vulnerability entries. The OSS-Fuzz bugs
are marked fix-verified but the syncer did not propagate the fix commit
to these YAML files.

- OSV-2024-396: UNKNOWN READ in `jvp_object_free`
- OSV-2024-440: UNKNOWN READ (NaN with payload)

## Evidence

- OSS-Fuzz issues marked fix-verified: https://issues.oss-fuzz.com/issues/42532548, #66323
- `jvp_object_free` no longer exists in jq-1.8.2 binary (confirmed via `nm`)
- jq maintainer confirmed fix: https://github.com/jqlang/jq/issues/3575
- Fix commit `34f7186b86743a083a589741b6cea95293524108` is the jq-1.8.2 release tag

## Changes

- Added `- fixed: 34f7186b86743a083a589741b6cea95293524108` to both YAML files
- Removed `jq-1.8.2` from affected versions (it contains the fix)

Related: https://github.com/google/oss-fuzz-vulns/issues/51

Note: Issue #51 tracks the broader pipeline sync question (why the syncer
missed these). This PR is the immediate data fix only.